### PR TITLE
feat: カメラホスト名の名前解決 + 手動入力 UI

### DIFF
--- a/atomcam_meteor/services/schedule_resolver.py
+++ b/atomcam_meteor/services/schedule_resolver.py
@@ -305,4 +305,5 @@ def get_current_camera_settings(
     db_settings = settings.get_all() if settings else {}
     return {
         "host": db_settings.get("camera.host", yaml_camera.host),
+        "yaml_host": yaml_camera.host,
     }

--- a/atomcam_meteor/web/routes.py
+++ b/atomcam_meteor/web/routes.py
@@ -679,6 +679,24 @@ def api_reset_camera_settings(
     return {"status": "reset", "deleted": deleted}
 
 
+@router.post("/api/settings/camera/resolve")
+def api_resolve_camera_host(
+    config: AppConfig = Depends(get_config),
+) -> dict:
+    """カメラのホスト名を IP アドレスに名前解決する。"""
+    import socket
+
+    hostname = config.camera.host
+    try:
+        ip_address = socket.gethostbyname(hostname)
+    except socket.gaierror as exc:
+        raise HTTPException(
+            status_code=502,
+            detail=f"ホスト名 '{hostname}' の名前解決に失敗しました: {exc}",
+        ) from exc
+    return {"hostname": hostname, "ip_address": ip_address}
+
+
 # ── ストレージ API ────────────────────────────────────────────────────
 
 @router.get("/api/storage/info")

--- a/atomcam_meteor/web/templates/admin.html
+++ b/atomcam_meteor/web/templates/admin.html
@@ -36,9 +36,28 @@
 <form id="cameraSettingsForm" onsubmit="return false;">
     <fieldset>
         <legend>カメラ接続</legend>
-        <label for="cameraHost">ホスト名 / IPアドレス</label>
-        <input type="text" id="cameraHost" name="host" placeholder="atomcam2.local または 192.168.1.105">
-        <small>ATOM Cam の mDNS ホスト名または IP アドレスを指定します。名前解決が不安定な場合は IP アドレスを直接入力してください。</small>
+        <label>YAML ホスト名</label>
+        <input type="text" id="cameraYamlHost" readonly style="background:var(--pico-form-element-disabled-background-color, #e9ecef); cursor:default;">
+        <small>設定ファイル (YAML) に記載されたホスト名です。変更するには YAML ファイルを直接編集してください。</small>
+
+        <div style="margin-top:1rem;">
+            <button type="button" id="resolveHostBtn" class="secondary outline" onclick="resolveHostname()" style="width:auto; font-size:0.8rem; padding:0.4rem 0.8rem;">名前解決</button>
+            <span id="resolveResult" style="margin-left:0.5rem; font-size:0.875rem;"></span>
+        </div>
+
+        <div style="margin-top:1rem;">
+            <label>使用するアドレス</label>
+            <label style="display:inline-flex; align-items:center; gap:0.5rem; margin-right:1.5rem; cursor:pointer;">
+                <input type="radio" name="cameraHostChoice" id="cameraChoiceHostname" value="hostname" checked onchange="updateCameraHostChoice()" style="margin:0;">
+                ホスト名を使用
+            </label>
+            <label style="display:inline-flex; align-items:center; gap:0.5rem; cursor:pointer;">
+                <input type="radio" name="cameraHostChoice" id="cameraChoiceIp" value="ip" disabled onchange="updateCameraHostChoice()" style="margin:0;">
+                IP アドレスを使用 <span id="cameraIpLabel"></span>
+            </label>
+        </div>
+        <input type="hidden" id="cameraHost" name="host">
+        <input type="hidden" id="cameraResolvedIp">
     </fieldset>
     <button type="button" class="outline contrast" onclick="resetSettings('camera')" style="width:auto; font-size:0.8rem; padding:0.4rem 0.8rem;">デフォルトに戻す</button>
 </form>
@@ -485,7 +504,65 @@ function populateSystemFields(sys) {
 }
 
 function populateCameraFields(cam) {
-    document.getElementById('cameraHost').value = cam.host || '';
+    var yamlHost = cam.yaml_host || '';
+    var currentHost = cam.host || yamlHost;
+    document.getElementById('cameraYamlHost').value = yamlHost;
+    document.getElementById('cameraHost').value = currentHost;
+
+    // IP 形式かどうか判定（簡易: 数字とドットのみ）
+    var isIp = /^\d{1,3}(\.\d{1,3}){3}$/.test(currentHost);
+    if (isIp && currentHost !== yamlHost) {
+        // 既に IP が保存されている場合、IP ラジオを有効化して選択
+        document.getElementById('cameraResolvedIp').value = currentHost;
+        document.getElementById('cameraChoiceIp').disabled = false;
+        document.getElementById('cameraChoiceIp').checked = true;
+        document.getElementById('cameraChoiceHostname').checked = false;
+        document.getElementById('cameraIpLabel').textContent = '(' + currentHost + ')';
+    } else {
+        document.getElementById('cameraChoiceHostname').checked = true;
+        document.getElementById('cameraChoiceIp').checked = false;
+    }
+}
+
+function resolveHostname() {
+    var btn = document.getElementById('resolveHostBtn');
+    var resultSpan = document.getElementById('resolveResult');
+    btn.disabled = true;
+    btn.setAttribute('aria-busy', 'true');
+    btn.textContent = '解決中...';
+    resultSpan.textContent = '';
+
+    fetch('/api/settings/camera/resolve', { method: 'POST' })
+        .then(function(r) {
+            if (!r.ok) return r.json().then(function(e) { throw new Error(e.detail || '名前解決失敗'); });
+            return r.json();
+        })
+        .then(function(data) {
+            var ip = data.ip_address;
+            document.getElementById('cameraResolvedIp').value = ip;
+            document.getElementById('cameraChoiceIp').disabled = false;
+            document.getElementById('cameraIpLabel').textContent = '(' + ip + ')';
+            resultSpan.textContent = data.hostname + ' → ' + ip;
+            showToast('名前解決成功: ' + ip, 'success');
+        })
+        .catch(function(err) {
+            resultSpan.textContent = '';
+            showToast('名前解決に失敗しました: ' + err.message, 'error');
+        })
+        .finally(function() {
+            btn.disabled = false;
+            btn.setAttribute('aria-busy', 'false');
+            btn.textContent = '名前解決';
+        });
+}
+
+function updateCameraHostChoice() {
+    var choice = document.querySelector('input[name="cameraHostChoice"]:checked').value;
+    if (choice === 'ip') {
+        document.getElementById('cameraHost').value = document.getElementById('cameraResolvedIp').value;
+    } else {
+        document.getElementById('cameraHost').value = document.getElementById('cameraYamlHost').value;
+    }
 }
 
 /* -- 保存 -- */

--- a/atomcam_meteor/web/templates/admin.html
+++ b/atomcam_meteor/web/templates/admin.html
@@ -51,10 +51,18 @@
                 <input type="radio" name="cameraHostChoice" id="cameraChoiceHostname" value="hostname" checked onchange="updateCameraHostChoice()" style="margin:0;">
                 ホスト名を使用
             </label>
-            <label style="display:inline-flex; align-items:center; gap:0.5rem; cursor:pointer;">
+            <label style="display:inline-flex; align-items:center; gap:0.5rem; margin-right:1.5rem; cursor:pointer;">
                 <input type="radio" name="cameraHostChoice" id="cameraChoiceIp" value="ip" disabled onchange="updateCameraHostChoice()" style="margin:0;">
-                IP アドレスを使用 <span id="cameraIpLabel"></span>
+                名前解決した IP <span id="cameraIpLabel"></span>
             </label>
+            <label style="display:inline-flex; align-items:center; gap:0.5rem; cursor:pointer;">
+                <input type="radio" name="cameraHostChoice" id="cameraChoiceManual" value="manual" onchange="updateCameraHostChoice()" style="margin:0;">
+                手動入力
+            </label>
+        </div>
+        <div id="cameraManualFields" style="display:none; margin-top:0.5rem;">
+            <input type="text" id="cameraManualIp" placeholder="192.168.1.105" oninput="onManualIpInput()">
+            <small>IP アドレスまたはホスト名を直接入力してください。</small>
         </div>
         <input type="hidden" id="cameraHost" name="host">
         <input type="hidden" id="cameraResolvedIp">
@@ -509,18 +517,16 @@ function populateCameraFields(cam) {
     document.getElementById('cameraYamlHost').value = yamlHost;
     document.getElementById('cameraHost').value = currentHost;
 
-    // IP 形式かどうか判定（簡易: 数字とドットのみ）
-    var isIp = /^\d{1,3}(\.\d{1,3}){3}$/.test(currentHost);
-    if (isIp && currentHost !== yamlHost) {
-        // 既に IP が保存されている場合、IP ラジオを有効化して選択
-        document.getElementById('cameraResolvedIp').value = currentHost;
-        document.getElementById('cameraChoiceIp').disabled = false;
-        document.getElementById('cameraChoiceIp').checked = true;
+    // 現在の保存値が YAML ホスト名と異なる場合の復元
+    if (currentHost !== yamlHost) {
+        // 手動入力欄に値をセットし「手動入力」を選択
+        document.getElementById('cameraManualIp').value = currentHost;
+        document.getElementById('cameraChoiceManual').checked = true;
         document.getElementById('cameraChoiceHostname').checked = false;
-        document.getElementById('cameraIpLabel').textContent = '(' + currentHost + ')';
+        document.getElementById('cameraManualFields').style.display = '';
     } else {
         document.getElementById('cameraChoiceHostname').checked = true;
-        document.getElementById('cameraChoiceIp').checked = false;
+        document.getElementById('cameraManualFields').style.display = 'none';
     }
 }
 
@@ -542,6 +548,9 @@ function resolveHostname() {
             document.getElementById('cameraResolvedIp').value = ip;
             document.getElementById('cameraChoiceIp').disabled = false;
             document.getElementById('cameraIpLabel').textContent = '(' + ip + ')';
+            document.getElementById('cameraChoiceIp').checked = true;
+            document.getElementById('cameraManualFields').style.display = 'none';
+            document.getElementById('cameraHost').value = ip;
             resultSpan.textContent = data.hostname + ' → ' + ip;
             showToast('名前解決成功: ' + ip, 'success');
         })
@@ -558,11 +567,21 @@ function resolveHostname() {
 
 function updateCameraHostChoice() {
     var choice = document.querySelector('input[name="cameraHostChoice"]:checked').value;
+    var manualFields = document.getElementById('cameraManualFields');
     if (choice === 'ip') {
+        manualFields.style.display = 'none';
         document.getElementById('cameraHost').value = document.getElementById('cameraResolvedIp').value;
+    } else if (choice === 'manual') {
+        manualFields.style.display = '';
+        document.getElementById('cameraHost').value = document.getElementById('cameraManualIp').value;
     } else {
+        manualFields.style.display = 'none';
         document.getElementById('cameraHost').value = document.getElementById('cameraYamlHost').value;
     }
+}
+
+function onManualIpInput() {
+    document.getElementById('cameraHost').value = document.getElementById('cameraManualIp').value;
 }
 
 /* -- 保存 -- */

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -668,6 +668,7 @@ class TestCameraSettingsAPI:
         assert resp.status_code == 200
         data = resp.json()
         assert data["host"] == "atomcam.local"
+        assert data["yaml_host"] == "atomcam.local"
 
     def test_put_and_get_camera(self, client):
         """カメラ設定の保存と取得"""
@@ -680,6 +681,7 @@ class TestCameraSettingsAPI:
         resp = client.get("/api/settings/camera")
         data = resp.json()
         assert data["host"] == "192.168.1.105"
+        assert data["yaml_host"] == "atomcam.local"
 
     def test_put_empty_body(self, client):
         """空のボディで 400 が返ること"""
@@ -698,6 +700,33 @@ class TestCameraSettingsAPI:
         resp = client.get("/api/settings/camera")
         data = resp.json()
         assert data["host"] == "atomcam.local"
+
+
+class TestResolveCameraHostAPI:
+    def test_resolve_camera_host(self, client, monkeypatch):
+        """名前解決が成功すること"""
+        import socket
+
+        monkeypatch.setattr(socket, "gethostbyname", lambda h: "192.168.1.100")
+
+        resp = client.post("/api/settings/camera/resolve")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["hostname"] == "atomcam.local"
+        assert data["ip_address"] == "192.168.1.100"
+
+    def test_resolve_camera_host_failure(self, client, monkeypatch):
+        """名前解決失敗時に 502 が返ること"""
+        import socket
+
+        def raise_gaierror(hostname):
+            raise socket.gaierror("Name or service not known")
+
+        monkeypatch.setattr(socket, "gethostbyname", raise_gaierror)
+
+        resp = client.post("/api/settings/camera/resolve")
+        assert resp.status_code == 502
+        assert "名前解決に失敗" in resp.json()["detail"]
 
 
 class TestStorageAPI:


### PR DESCRIPTION
## 概要
- YAML ホスト名を IP アドレスに名前解決するボタンと API エンドポイントを追加
- ホスト名 / 名前解決 IP / 手動入力の3択ラジオボタンで使用するアドレスを選択可能に
- 名前解決できない環境でも IP やホスト名を直接入力できるフォールバックを提供

## テスト計画
- [x] `uv run pytest` 全304テスト通過
- [ ] Web UI で名前解決ボタン → IP 表示 → 選択 → 保存の一連操作を確認
- [ ] 手動入力 → 保存 → リロード後の復元を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)